### PR TITLE
Reduce APK size

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,7 +13,10 @@ android {
     }
     buildTypes {
         release {
-            minifyEnabled false
+            shrinkResources true
+            minifyEnabled true
+            zipAlignEnabled true
+            useProguard true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }


### PR DESCRIPTION
This reduces release apk size from 1,411,017 bytes to 718,950 bytes

Note this does enable obfuscation (a requirement of shrinkResources), if needed I'll disable that.