### PR TITLE
Add Huawei to blacklist

### DIFF
--- a/app/src/main/java/org/fitchfamily/android/dejavu/RfEmitter.java
+++ b/app/src/main/java/org/fitchfamily/android/dejavu/RfEmitter.java
@@ -618,6 +618,7 @@ public class RfEmitter {
         boolean rslt =
                 // Mobile phone brands
                 lc.contains("android") ||                   // mobile tethering
+                lc.startsWith("HUAWEI-") ||
                 lc.contains("ipad") ||                      // mobile tethering
                 lc.contains("iphone") ||                    // mobile tethering
                 lc.contains("motorola") ||                  // mobile tethering


### PR DESCRIPTION
I've observed several instances of such SSIDs while capturing data with various apps.

In my experience, they're always mobile phones.